### PR TITLE
Implement environment support

### DIFF
--- a/assets/assets.go
+++ b/assets/assets.go
@@ -11,19 +11,19 @@ var _Assets7e9bedb64677d9d3d7167b59bc342e1eb5dbd8d8 = "package main\n\nimport (\
 
 // Assets returns go-assets FileSystem
 var Assets = assets.NewFileSystem(map[string][]string{"/": []string{"ale", "main.go.template"}}, map[string]*assets.File{
-	"/main.go.template": &assets.File{
-		Path:     "/main.go.template",
-		FileMode: 0x1a4,
-		Mtime:    time.Unix(1519130263, 1519130263000000000),
-		Data:     []byte(_Assets7e9bedb64677d9d3d7167b59bc342e1eb5dbd8d8),
-	}, "/": &assets.File{
+	"/": &assets.File{
 		Path:     "/",
 		FileMode: 0x800001ed,
-		Mtime:    time.Unix(1519130263, 1519130263000000000),
+		Mtime:    time.Unix(1534654234, 1534654234703348760),
 		Data:     nil,
 	}, "/ale": &assets.File{
 		Path:     "/ale",
 		FileMode: 0x1a4,
-		Mtime:    time.Unix(1518347191, 1518347191000000000),
+		Mtime:    time.Unix(1534654234, 1534654234703245073),
 		Data:     []byte(_Assetsdbfa9bb4fc5340440719a646c285441fc9134ddd),
+	}, "/main.go.template": &assets.File{
+		Path:     "/main.go.template",
+		FileMode: 0x1a4,
+		Mtime:    time.Unix(1534654234, 1534654234703426397),
+		Data:     []byte(_Assets7e9bedb64677d9d3d7167b59bc342e1eb5dbd8d8),
 	}}, "")

--- a/entity/function.go
+++ b/entity/function.go
@@ -7,11 +7,12 @@ type VPC struct {
 
 // Function is the entity struct which maps from configuration.
 type Function struct {
-	Name       string  `toml:"name"`
-	Arn        string  `toml:"arn"`
-	MemorySize int64   `toml:"memory_size"`
-	Timeout    int64   `toml:"timeout"`
-	Role       string  `toml:"role"`
-	Schedule   *string `toml:"schedule"`
-	VPC        *VPC    `toml:"vpc"`
+	Name        string             `toml:"name"`
+	Arn         string             `toml:"arn"`
+	MemorySize  int64              `toml:"memory_size"`
+	Timeout     int64              `toml:"timeout"`
+	Role        string             `toml:"role"`
+	Schedule    *string            `toml:"schedule"`
+	VPC         *VPC               `toml:"vpc"`
+	Environment map[string]*string `toml:"environment"`
 }

--- a/request/lambda.go
+++ b/request/lambda.go
@@ -128,6 +128,11 @@ func (l *LambdaRequest) CreateFunction(fn *entity.Function, zipBytes []byte) (st
 		Runtime:      aws.String("go1.x"),
 		Timeout:      aws.Int64(fn.Timeout),
 	}
+	if fn.Environment != nil {
+		input = input.SetEnvironment(&lambda.Environment{
+			Variables: fn.Environment,
+		})
+	}
 	// Append VPC configuration if specified
 	if fn.VPC != nil {
 		sn := []*string{}
@@ -274,6 +279,11 @@ func (l *LambdaRequest) UpdateFunctionConfiguration(fn *entity.Function) error {
 		input = input.SetVpcConfig(&lambda.VpcConfig{
 			SubnetIds:        sn,
 			SecurityGroupIds: sg,
+		})
+	}
+	if fn.Environment != nil {
+		input = input.SetEnvironment(&lambda.Environment{
+			Variables: fn.Environment,
 		})
 	}
 	debugRequest(input)


### PR DESCRIPTION
This PR implements environment variables support for lambda function.

### Changes

We can specify some environment variables at `[environment]` section in `Function.toml`:

```toml
[environment]
Some = "value"
```
