### PR TITLE
Enable to change tmp dir through env

### DIFF
--- a/command/deploy.go
+++ b/command/deploy.go
@@ -219,9 +219,16 @@ func (d *Deploy) deployFunction(c *config.Config, ctx *args.Context) error {
 		return nil
 	}
 
-	buildDir, err := ioutil.TempDir("", "ginger-builds")
-	if err != nil {
-		return exception(err.Error())
+	var buildDir string
+	var buildDirErr error
+	if os.Getenv("GINGER_TMP_DIR") != "" {
+		buildDir = os.Getenv("GINGER_TMP_DIR")
+		buildDirErr = os.Mkdir(buildDir, 0755)
+	} else {
+		buildDir, buildDirErr = ioutil.TempDir("", "ginger-builds")
+	}
+	if buildDirErr != nil {
+		return exception(buildDirErr.Error())
 	}
 	defer os.RemoveAll(buildDir)
 

--- a/command/install.go
+++ b/command/install.go
@@ -112,7 +112,18 @@ func (i *Install) Run(ctx *args.Context) error {
 		}
 	}
 
-	tmpDir, _ := ioutil.TempDir("", "ginger-tmp-packages")
+	var tmpDir string
+	var err error
+	if os.Getenv("GINGER_TMP_DIR") != "" {
+		tmpDir = os.Getenv("GINGER_TMP_DIR")
+		err = os.Mkdir(tmpDir, 0755)
+	} else {
+		tmpDir, err = ioutil.TempDir("", "ginger-tmp-packages")
+	}
+	if err != nil {
+		i.log.Error("Failed to create tmp dir: " + err.Error())
+		return err
+	}
 	defer os.RemoveAll(tmpDir)
 
 	deps, err := findDependencyPackages(c.FunctionPath)


### PR DESCRIPTION
This PR enables to change install/build temporary directory because some build service which using docker container (e.g. AWS codebuild) sometimes cannot use `/tmp` directory due to mount other host.

To fix it, we need to change temporary directory through the environment variable of `GINGER_TMP_DIR`.