### PR TITLE
skip whitelist packages in config

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -15,3 +15,4 @@
 vendor
 dist/ginger
 ginger
+.envrc

--- a/assets/assets.go
+++ b/assets/assets.go
@@ -6,71 +6,71 @@ import (
 	"github.com/jessevdk/go-assets"
 )
 
-var _Assetscf0a4761df7feb6a438061dcb60d29eb41dd9c64 = "{\n  \"requestContext\": {\n    \"elb\": {\n      \"targetGroupArn\": \"arn:aws:elasticloadbalancing:region:123456789012:targetgroup/my-target-group/6d0ecf831eec9f09\"\n    }\n  },\n  \"httpMethod\": \"GET\",\n  \"path\": \"/\",\n  \"queryStringParameters\": {\n    \"testparam\": \"true\"\n  },\n  \"multiValueQueryStringParameters\": {\n    \"name\": [\"me\"]\n  },\n  \"headers\": {\n    \"accept\": \"text/html,application/xhtml+xml\",\n    \"accept-language\": \"en-US,en;q=0.8\",\n    \"content-type\": \"text/plain\",\n    \"cookie\": \"cookies\",\n    \"host\": \"lambda-846800462-us-east-2.elb.amazonaws.com\",\n    \"user-agent\": \"Mozilla/5.0 (Macintosh; Intel Mac OS X 10_11_6)\",\n    \"x-amzn-trace-id\": \"Root=1-5bdb40ca-556d8b0c50dc66f0511bf520\",\n    \"x-forwarded-for\": \"72.21.198.66\",\n    \"x-forwarded-port\": \"443\",\n    \"x-forwarded-proto\": \"https\"\n  },\n  \"multiValueHeaders\": {\n    \"Accept\": [\"*/*\"],\n    \"Accept-Encoding\": [\"gzip, deflate\"],\n    \"cache-control\": [\"no-cache\"],\n    \"CloudFront-Forwarded-Proto\": [\"https\"],\n    \"CloudFront-Is-Desktop-Viewer\": [\"true\"],\n    \"CloudFront-Is-Mobile-Viewer\": [\"false\"],\n    \"CloudFront-Is-SmartTV-Viewer\": [\"false\"],\n    \"CloudFront-Is-Tablet-Viewer\": [\"false\"],\n    \"CloudFront-Viewer-Country\": [\"US\"],\n    \"Content-Type\": [\"application/json\"],\n    \"headerName\": [\"headerValue\"],\n    \"Host\": [\"gy415nuibc.execute-api.us-east-1.amazonaws.com\"],\n    \"Postman-Token\": [\"9f583ef0-ed83-4a38-aef3-eb9ce3f7a57f\"],\n    \"User-Agent\": [\"PostmanRuntime/2.4.5\"],\n    \"Via\": [\"1.1 d98420743a69852491bbdea73f7680bd.cloudfront.net (CloudFront)\"],\n    \"X-Amz-Cf-Id\": [\"pn-PWIJc6thYnZm5P0NMgOUglL1DYtl0gdeJky8tqsg8iS_sgsKD1A==\"],\n    \"X-Forwarded-For\": [\"54.240.196.186, 54.182.214.83\"],\n    \"X-Forwarded-Port\": [\"443\"],\n    \"X-Forwarded-Proto\": [\"https\"]\n  },\n  \"isBase64Encoded\": false,\n  \"body\": \"Who there?\"\n}\n"
-var _Assetsc3406f0ca413d793c94444f1987a931df2b59912 = "{\n  \"body\": \"eyJ0ZXN0IjoiYm9keSJ9\",\n  \"resource\": \"/{proxy+}\",\n  \"path\": \"/path/to/resource\",\n  \"httpMethod\": \"POST\",\n  \"isBase64Encoded\": true,\n  \"queryStringParameters\": {\n    \"foo\": \"bar\"\n  },\n  \"pathParameters\": {\n    \"proxy\": \"/path/to/resource\"\n  },\n  \"stageVariables\": {\n    \"baz\": \"qux\"\n  },\n  \"headers\": {\n    \"Accept\": \"text/html,application/xhtml+xml,application/xml;q=0.9,image/webp,*/*;q=0.8\",\n    \"Accept-Encoding\": \"gzip, deflate, sdch\",\n    \"Accept-Language\": \"en-US,en;q=0.8\",\n    \"Cache-Control\": \"max-age=0\",\n    \"CloudFront-Forwarded-Proto\": \"https\",\n    \"CloudFront-Is-Desktop-Viewer\": \"true\",\n    \"CloudFront-Is-Mobile-Viewer\": \"false\",\n    \"CloudFront-Is-SmartTV-Viewer\": \"false\",\n    \"CloudFront-Is-Tablet-Viewer\": \"false\",\n    \"CloudFront-Viewer-Country\": \"US\",\n    \"Host\": \"1234567890.execute-api.ap-northeast-1.amazonaws.com\",\n    \"Upgrade-Insecure-Requests\": \"1\",\n    \"User-Agent\": \"Custom User Agent String\",\n    \"Via\": \"1.1 08f323deadbeefa7af34d5feb414ce27.cloudfront.net (CloudFront)\",\n    \"X-Amz-Cf-Id\": \"cDehVQoZnx43VYQb9j2-nvCh-9z396Uhbp027Y2JvkCPNLmGJHqlaA==\",\n    \"X-Forwarded-For\": \"127.0.0.1, 127.0.0.2\",\n    \"X-Forwarded-Port\": \"443\",\n    \"X-Forwarded-Proto\": \"https\"\n  },\n  \"requestContext\": {\n    \"accountId\": \"123456789012\",\n    \"resourceId\": \"123456\",\n    \"stage\": \"prod\",\n    \"requestId\": \"c6af9ac6-7b61-11e6-9a41-93e8deadbeef\",\n    \"requestTime\": \"09/Apr/2015:12:34:56 +0000\",\n    \"requestTimeEpoch\": 1428582896000,\n    \"identity\": {\n      \"cognitoIdentityPoolId\": null,\n      \"accountId\": null,\n      \"cognitoIdentityId\": null,\n      \"caller\": null,\n      \"accessKey\": null,\n      \"sourceIp\": \"127.0.0.1\",\n      \"cognitoAuthenticationType\": null,\n      \"cognitoAuthenticationProvider\": null,\n      \"userArn\": null,\n      \"userAgent\": \"Custom User Agent String\",\n      \"user\": null\n    },\n    \"path\": \"/prod/path/to/resource\",\n    \"resourcePath\": \"/{proxy+}\",\n    \"httpMethod\": \"POST\",\n    \"apiId\": \"1234567890\",\n    \"protocol\": \"HTTP/1.1\"\n  }\n}\n"
-var _Assets4518a7bcadf80bb83fed670406e243eb329230b9 = "{\n  \"Records\": [\n    {\n      \"eventVersion\": \"2.0\",\n      \"eventSource\": \"aws:s3\",\n      \"awsRegion\": \"ap-northeast-1\",\n      \"eventTime\": \"1970-01-01T00:00:00.000Z\",\n      \"eventName\": \"ObjectCreated:Put\",\n      \"userIdentity\": {\n        \"principalId\": \"EXAMPLE\"\n      },\n      \"requestParameters\": {\n        \"sourceIPAddress\": \"127.0.0.1\"\n      },\n      \"responseElements\": {\n        \"x-amz-request-id\": \"EXAMPLE123456789\",\n        \"x-amz-id-2\": \"EXAMPLE123/5678abcdefghijklambdaisawesome/mnopqrstuvwxyzABCDEFGH\"\n      },\n      \"s3\": {\n        \"s3SchemaVersion\": \"1.0\",\n        \"configurationId\": \"testConfigRule\",\n        \"bucket\": {\n          \"name\": \"example-bucket\",\n          \"ownerIdentity\": {\n            \"principalId\": \"EXAMPLE\"\n          },\n          \"arn\": \"arn:aws:s3:::example-bucket\"\n        },\n        \"object\": {\n          \"key\": \"test/key\",\n          \"size\": 1024,\n          \"eTag\": \"0123456789abcdef0123456789abcdef\",\n          \"sequencer\": \"0A1B2C3D4E5F678901\"\n        }\n      }\n    }\n  ]\n}\n"
 var _Assetsd9992443cfb1220a23b5342e8a1f495a21bea1fb = "{\n  \"key1\": \"value1\",\n  \"key2\": \"value2\",\n  \"key3\": \"value3\"\n}\n"
 var _Assetsdbfa9bb4fc5340440719a646c285441fc9134ddd = "SG9tZSBNYWRlIEdpbmdlciBBbGUKCiMjLSBJTkdSRURJRU5UUwotIDEgMS8yIGN1cHMgY2hvcHBlZCBwZWVsZWQgZ2luZ2VyICg3IG91bmNlcykKLSAyIGN1cHMgd2F0ZXIKLSAzLzQgY3VwIHN1Z2FyCi0gQWJvdXQgMSBxdWFydCBjaGlsbGVkIHNlbHR6ZXIgb3IgY2x1YiBzb2RhCi0gQWJvdXQgMyB0YWJsZXNwb29ucyBmcmVzaCBsaW1lIGp1aWNlCgojIyBQUkVQQVJBVElPTgoKIyMjIE1ha2Ugc3lydXA6CkNvb2sgZ2luZ2VyIGluIHdhdGVyIGluIGEgc21hbGwgc2F1Y2VwYW4gYXQgYSBsb3cgc2ltbWVyLCBwYXJ0aWFsbHkgY292ZXJlZCwgNDUgbWludXRlcy4gUmVtb3ZlIGZyb20gaGVhdCBhbmQgbGV0IHN0ZWVwLCBjb3ZlcmVkLCAyMCBtaW51dGVzLgpTdHJhaW4gbWl4dHVyZSB0aHJvdWdoIGEgc2lldmUgaW50byBhIGJvd2wsIHByZXNzaW5nIG9uIGdpbmdlciBhbmQgdGhlbiBkaXNjYXJkaW5nLiBSZXR1cm4gbGlxdWlkIHRvIHNhdWNlcGFuIGFuZCBhZGQgc3VnYXIgYW5kIGEgcGluY2ggb2Ygc2FsdCwgdGhlbiBoZWF0IG92ZXIgbWVkaXVtIGhlYXQsIHN0aXJyaW5nLCB1bnRpbCBzdWdhciBoYXMgZGlzc29sdmVkLiBDaGlsbCBzeXJ1cCBpbiBhIGNvdmVyZWQgamFyIHVudGlsIGNvbGQuCgojIyMgQXNzZW1ibGUgZHJpbmtzOgpNaXggZ2luZ2VyIHN5cnVwIHdpdGggc2VsdHplciBhbmQgbGltZSBqdWljZSAoc3RhcnQgd2l0aCAxLzQgY3VwIHN5cnVwIGFuZCAxIDEvMiB0ZWFzcG9vbnMgbGltZSBqdWljZSBwZXIgMy80IGN1cCBzZWx0emVyLCB0aGVuIGFkanVzdCB0byB0YXN0ZSkuCg==\n"
-var _Assets7e9bedb64677d9d3d7167b59bc342e1eb5dbd8d8 = "package main\n\nimport (\n\t\"context\"\n\n\t\"github.com/aws/aws-lambda-go/lambda\"%s\n)\n\nfunc %sHandler(ctx context.Context, %s) %s {\n\treturn %s\n}\n\nfunc main() {\n\tlambda.Start(%sHandler)\n}\n"
+var _Assetscf0a4761df7feb6a438061dcb60d29eb41dd9c64 = "{\n  \"requestContext\": {\n    \"elb\": {\n      \"targetGroupArn\": \"arn:aws:elasticloadbalancing:region:123456789012:targetgroup/my-target-group/6d0ecf831eec9f09\"\n    }\n  },\n  \"httpMethod\": \"GET\",\n  \"path\": \"/\",\n  \"queryStringParameters\": {\n    \"testparam\": \"true\"\n  },\n  \"multiValueQueryStringParameters\": {\n    \"name\": [\"me\"]\n  },\n  \"headers\": {\n    \"accept\": \"text/html,application/xhtml+xml\",\n    \"accept-language\": \"en-US,en;q=0.8\",\n    \"content-type\": \"text/plain\",\n    \"cookie\": \"cookies\",\n    \"host\": \"lambda-846800462-us-east-2.elb.amazonaws.com\",\n    \"user-agent\": \"Mozilla/5.0 (Macintosh; Intel Mac OS X 10_11_6)\",\n    \"x-amzn-trace-id\": \"Root=1-5bdb40ca-556d8b0c50dc66f0511bf520\",\n    \"x-forwarded-for\": \"72.21.198.66\",\n    \"x-forwarded-port\": \"443\",\n    \"x-forwarded-proto\": \"https\"\n  },\n  \"multiValueHeaders\": {\n    \"Accept\": [\"*/*\"],\n    \"Accept-Encoding\": [\"gzip, deflate\"],\n    \"cache-control\": [\"no-cache\"],\n    \"CloudFront-Forwarded-Proto\": [\"https\"],\n    \"CloudFront-Is-Desktop-Viewer\": [\"true\"],\n    \"CloudFront-Is-Mobile-Viewer\": [\"false\"],\n    \"CloudFront-Is-SmartTV-Viewer\": [\"false\"],\n    \"CloudFront-Is-Tablet-Viewer\": [\"false\"],\n    \"CloudFront-Viewer-Country\": [\"US\"],\n    \"Content-Type\": [\"application/json\"],\n    \"headerName\": [\"headerValue\"],\n    \"Host\": [\"gy415nuibc.execute-api.us-east-1.amazonaws.com\"],\n    \"Postman-Token\": [\"9f583ef0-ed83-4a38-aef3-eb9ce3f7a57f\"],\n    \"User-Agent\": [\"PostmanRuntime/2.4.5\"],\n    \"Via\": [\"1.1 d98420743a69852491bbdea73f7680bd.cloudfront.net (CloudFront)\"],\n    \"X-Amz-Cf-Id\": [\"pn-PWIJc6thYnZm5P0NMgOUglL1DYtl0gdeJky8tqsg8iS_sgsKD1A==\"],\n    \"X-Forwarded-For\": [\"54.240.196.186, 54.182.214.83\"],\n    \"X-Forwarded-Port\": [\"443\"],\n    \"X-Forwarded-Proto\": [\"https\"]\n  },\n  \"isBase64Encoded\": false,\n  \"body\": \"Who there?\"\n}\n"
 var _Assetsbe9b29afa5a5b73964a58457509a59df526ece33 = "{\n  \"id\": \"cdc73f9d-aea9-11e3-9d5a-835b769c0d9c\",\n  \"detail-type\": \"Scheduled Event\",\n  \"source\": \"aws.events\",\n  \"account\": \"{{account-id}}\",\n  \"time\": \"1970-01-01T00:00:00Z\",\n  \"region\": \"ap-northeast-1\",\n  \"resources\": [\n    \"arn:aws:events:ap-northeast-1:123456789012:rule/ExampleRule\"\n  ],\n  \"detail\": {}\n}\n"
+var _Assetsc3406f0ca413d793c94444f1987a931df2b59912 = "{\n  \"body\": \"eyJ0ZXN0IjoiYm9keSJ9\",\n  \"resource\": \"/{proxy+}\",\n  \"path\": \"/path/to/resource\",\n  \"httpMethod\": \"POST\",\n  \"isBase64Encoded\": true,\n  \"queryStringParameters\": {\n    \"foo\": \"bar\"\n  },\n  \"pathParameters\": {\n    \"proxy\": \"/path/to/resource\"\n  },\n  \"stageVariables\": {\n    \"baz\": \"qux\"\n  },\n  \"headers\": {\n    \"Accept\": \"text/html,application/xhtml+xml,application/xml;q=0.9,image/webp,*/*;q=0.8\",\n    \"Accept-Encoding\": \"gzip, deflate, sdch\",\n    \"Accept-Language\": \"en-US,en;q=0.8\",\n    \"Cache-Control\": \"max-age=0\",\n    \"CloudFront-Forwarded-Proto\": \"https\",\n    \"CloudFront-Is-Desktop-Viewer\": \"true\",\n    \"CloudFront-Is-Mobile-Viewer\": \"false\",\n    \"CloudFront-Is-SmartTV-Viewer\": \"false\",\n    \"CloudFront-Is-Tablet-Viewer\": \"false\",\n    \"CloudFront-Viewer-Country\": \"US\",\n    \"Host\": \"1234567890.execute-api.ap-northeast-1.amazonaws.com\",\n    \"Upgrade-Insecure-Requests\": \"1\",\n    \"User-Agent\": \"Custom User Agent String\",\n    \"Via\": \"1.1 08f323deadbeefa7af34d5feb414ce27.cloudfront.net (CloudFront)\",\n    \"X-Amz-Cf-Id\": \"cDehVQoZnx43VYQb9j2-nvCh-9z396Uhbp027Y2JvkCPNLmGJHqlaA==\",\n    \"X-Forwarded-For\": \"127.0.0.1, 127.0.0.2\",\n    \"X-Forwarded-Port\": \"443\",\n    \"X-Forwarded-Proto\": \"https\"\n  },\n  \"requestContext\": {\n    \"accountId\": \"123456789012\",\n    \"resourceId\": \"123456\",\n    \"stage\": \"prod\",\n    \"requestId\": \"c6af9ac6-7b61-11e6-9a41-93e8deadbeef\",\n    \"requestTime\": \"09/Apr/2015:12:34:56 +0000\",\n    \"requestTimeEpoch\": 1428582896000,\n    \"identity\": {\n      \"cognitoIdentityPoolId\": null,\n      \"accountId\": null,\n      \"cognitoIdentityId\": null,\n      \"caller\": null,\n      \"accessKey\": null,\n      \"sourceIp\": \"127.0.0.1\",\n      \"cognitoAuthenticationType\": null,\n      \"cognitoAuthenticationProvider\": null,\n      \"userArn\": null,\n      \"userAgent\": \"Custom User Agent String\",\n      \"user\": null\n    },\n    \"path\": \"/prod/path/to/resource\",\n    \"resourcePath\": \"/{proxy+}\",\n    \"httpMethod\": \"POST\",\n    \"apiId\": \"1234567890\",\n    \"protocol\": \"HTTP/1.1\"\n  }\n}\n"
 var _Assetsbcc7ff0fb173f4d7324a5d571efda92a9339a0d1 = "{\n  \"Records\": [\n    {\n      \"messageId\": \"19dd0b57-b21e-4ac1-bd88-01bbb068cb78\",\n      \"receiptHandle\": \"MessageReceiptHandle\",\n      \"body\": \"Hello from SQS!\",\n      \"attributes\": {\n        \"ApproximateReceiveCount\": \"1\",\n        \"SentTimestamp\": \"1523232000000\",\n        \"SenderId\": \"123456789012\",\n        \"ApproximateFirstReceiveTimestamp\": \"1523232000001\"\n      },\n      \"messageAttributes\": {},\n      \"md5OfBody\": \"7b270e59b47ff90a553787216d55d91d\",\n      \"eventSource\": \"aws:sqs\",\n      \"eventSourceARN\": \"arn:aws:sqs:ap-northeast-1:123456789012:MyQueue\",\n      \"awsRegion\": \"ap-northeast-1\"\n    }\n  ]\n}\n"
+var _Assets7e9bedb64677d9d3d7167b59bc342e1eb5dbd8d8 = "package main\n\nimport (\n\t\"context\"\n\n\t\"github.com/aws/aws-lambda-go/lambda\"%s\n)\n\nfunc %sHandler(ctx context.Context, %s) %s {\n\treturn %s\n}\n\nfunc main() {\n\tlambda.Start(%sHandler)\n}\n"
+var _Assets4518a7bcadf80bb83fed670406e243eb329230b9 = "{\n  \"Records\": [\n    {\n      \"eventVersion\": \"2.0\",\n      \"eventSource\": \"aws:s3\",\n      \"awsRegion\": \"ap-northeast-1\",\n      \"eventTime\": \"1970-01-01T00:00:00.000Z\",\n      \"eventName\": \"ObjectCreated:Put\",\n      \"userIdentity\": {\n        \"principalId\": \"EXAMPLE\"\n      },\n      \"requestParameters\": {\n        \"sourceIPAddress\": \"127.0.0.1\"\n      },\n      \"responseElements\": {\n        \"x-amz-request-id\": \"EXAMPLE123456789\",\n        \"x-amz-id-2\": \"EXAMPLE123/5678abcdefghijklambdaisawesome/mnopqrstuvwxyzABCDEFGH\"\n      },\n      \"s3\": {\n        \"s3SchemaVersion\": \"1.0\",\n        \"configurationId\": \"testConfigRule\",\n        \"bucket\": {\n          \"name\": \"example-bucket\",\n          \"ownerIdentity\": {\n            \"principalId\": \"EXAMPLE\"\n          },\n          \"arn\": \"arn:aws:s3:::example-bucket\"\n        },\n        \"object\": {\n          \"key\": \"test/key\",\n          \"size\": 1024,\n          \"eTag\": \"0123456789abcdef0123456789abcdef\",\n          \"sequencer\": \"0A1B2C3D4E5F678901\"\n        }\n      }\n    }\n  ]\n}\n"
 var _Assets81333d4b73a793367bc91199decc7a8f55834599 = "{\n  \"invocationId\": \"invocationIdExample\",\n  \"deliverySteamArn\": \"arn:aws:kinesis:EXAMPLE\",\n  \"region\": \"ap-northeast-1\",\n  \"records\": [\n    {\n      \"recordId\": \"49546986683135544286507457936321625675700192471156785154\",\n      \"approximateArrivalTimestamp\": 1495072949453,\n      \"kinesisRecordMetadata\": {\n        \"sequenceNumber\": \"49545115243490985018280067714973144582180062593244200961\",\n        \"subsequenceNumber\": \"123456\",\n        \"partitionKey\": \"partitionKey-03\",\n        \"shardId\": \"shardId-000000000000\",\n        \"approximateArrivalTimestamp\": 1495072949453\n      },\n      \"data\": \"SGVsbG8sIHRoaXMgaXMgYSB0ZXN0IDEyMy4=\"\n    }\n  ]\n}\n"
 
 // Assets returns go-assets FileSystem
 var Assets = assets.NewFileSystem(map[string][]string{"/": []string{"ale", "main.go.template"}, "/events": []string{"alb.json", "cloudwatch.json", "apigateway.json", "s3.json", "sqs.json", "default.json", "kinesis.json"}}, map[string]*assets.File{
-	"/ale": &assets.File{
-		Path:     "/ale",
+	"/events": &assets.File{
+		Path:     "/events",
+		FileMode: 0x800001ed,
+		Mtime:    time.Unix(1563443583, 1563443583920522045),
+		Data:     nil,
+	}, "/events/s3.json": &assets.File{
+		Path:     "/events/s3.json",
 		FileMode: 0x1a4,
-		Mtime:    time.Unix(1534654234, 1534654234703245073),
-		Data:     []byte(_Assetsdbfa9bb4fc5340440719a646c285441fc9134ddd),
-	}, "/main.go.template": &assets.File{
-		Path:     "/main.go.template",
-		FileMode: 0x1a4,
-		Mtime:    time.Unix(1534654234, 1534654234703426397),
-		Data:     []byte(_Assets7e9bedb64677d9d3d7167b59bc342e1eb5dbd8d8),
-	}, "/events/cloudwatch.json": &assets.File{
-		Path:     "/events/cloudwatch.json",
-		FileMode: 0x1a4,
-		Mtime:    time.Unix(1544425862, 1544425862820000310),
-		Data:     []byte(_Assetsbe9b29afa5a5b73964a58457509a59df526ece33),
-	}, "/events/sqs.json": &assets.File{
-		Path:     "/events/sqs.json",
-		FileMode: 0x1a4,
-		Mtime:    time.Unix(1544425862, 1544425862821965681),
-		Data:     []byte(_Assetsbcc7ff0fb173f4d7324a5d571efda92a9339a0d1),
+		Mtime:    time.Unix(1546791281, 1546791281764879064),
+		Data:     []byte(_Assets4518a7bcadf80bb83fed670406e243eb329230b9),
 	}, "/events/kinesis.json": &assets.File{
 		Path:     "/events/kinesis.json",
 		FileMode: 0x1a4,
-		Mtime:    time.Unix(1544425862, 1544425862820925991),
+		Mtime:    time.Unix(1546791281, 1546791281764725167),
 		Data:     []byte(_Assets81333d4b73a793367bc91199decc7a8f55834599),
 	}, "/": &assets.File{
 		Path:     "/",
 		FileMode: 0x800001ed,
-		Mtime:    time.Unix(1544425862, 1544425862818864630),
+		Mtime:    time.Unix(1546791281, 1546791281765143672),
 		Data:     nil,
-	}, "/events": &assets.File{
-		Path:     "/events",
-		FileMode: 0x800001ed,
-		Mtime:    time.Unix(1546827916, 1546827916016750654),
-		Data:     nil,
+	}, "/main.go.template": &assets.File{
+		Path:     "/main.go.template",
+		FileMode: 0x1a4,
+		Mtime:    time.Unix(1546791281, 1546791281765203145),
+		Data:     []byte(_Assets7e9bedb64677d9d3d7167b59bc342e1eb5dbd8d8),
 	}, "/events/alb.json": &assets.File{
 		Path:     "/events/alb.json",
 		FileMode: 0x1a4,
-		Mtime:    time.Unix(1546827916, 1546827916016862462),
+		Mtime:    time.Unix(1563443583, 1563443583920655596),
 		Data:     []byte(_Assetscf0a4761df7feb6a438061dcb60d29eb41dd9c64),
+	}, "/events/cloudwatch.json": &assets.File{
+		Path:     "/events/cloudwatch.json",
+		FileMode: 0x1a4,
+		Mtime:    time.Unix(1546791281, 1546791281764469740),
+		Data:     []byte(_Assetsbe9b29afa5a5b73964a58457509a59df526ece33),
 	}, "/events/apigateway.json": &assets.File{
 		Path:     "/events/apigateway.json",
 		FileMode: 0x1a4,
-		Mtime:    time.Unix(1544425862, 1544425862819495643),
+		Mtime:    time.Unix(1546791281, 1546791281764353584),
 		Data:     []byte(_Assetsc3406f0ca413d793c94444f1987a931df2b59912),
-	}, "/events/s3.json": &assets.File{
-		Path:     "/events/s3.json",
+	}, "/events/sqs.json": &assets.File{
+		Path:     "/events/sqs.json",
 		FileMode: 0x1a4,
-		Mtime:    time.Unix(1544425862, 1544425862821554368),
-		Data:     []byte(_Assets4518a7bcadf80bb83fed670406e243eb329230b9),
+		Mtime:    time.Unix(1546791281, 1546791281765014515),
+		Data:     []byte(_Assetsbcc7ff0fb173f4d7324a5d571efda92a9339a0d1),
 	}, "/events/default.json": &assets.File{
 		Path:     "/events/default.json",
 		FileMode: 0x1a4,
-		Mtime:    time.Unix(1544425862, 1544425862820466237),
+		Mtime:    time.Unix(1546791281, 1546791281764571518),
 		Data:     []byte(_Assetsd9992443cfb1220a23b5342e8a1f495a21bea1fb),
+	}, "/ale": &assets.File{
+		Path:     "/ale",
+		FileMode: 0x1a4,
+		Mtime:    time.Unix(1546791281, 1546791281764175249),
+		Data:     []byte(_Assetsdbfa9bb4fc5340440719a646c285441fc9134ddd),
 	}}, "")

--- a/config/config.go
+++ b/config/config.go
@@ -34,6 +34,7 @@ type Config struct {
 	S3BucketName      string             `toml:"s3_bucket_name"`
 	DeployHookCommand string             `toml:"deploy_hook_command"`
 	Resources         []*entity.Resource `toml:"resources"`
+	LocalPackages     []string           `toml:"local_packages"`
 
 	Queue map[string]*entity.Function `toml:"-"`
 	log   *logger.Logger              `toml:"-"`


### PR DESCRIPTION
This PR adds configuration field which enables to skip installation from latest via `go get`.

For instance, we can add `local_packages` field as array of string;

```toml
// Ginger.toml
...
local_packages = [
  "github.com/ysugimoto/ginger/command" # This is just for example for ignoring install
]
```

And then you run `ginger install`, skip installation for local_packages definition respectively and remove from internal library path if exists.